### PR TITLE
More tests and minor fixes

### DIFF
--- a/src/cljx/instar/core.cljx
+++ b/src/cljx/instar/core.cljx
@@ -6,6 +6,9 @@
 
 (defn- noop [x] x)
 
+(defn- name* [x]
+  (if (number? x) (str x) (name x)))
+
 (defn- split-at-exclusive [index path]
   (let [[a b] (split-at index path)]
     [(into [] a)
@@ -35,7 +38,7 @@
             (cond
              (star? crumb)  (expand-path-with state base (constantly true))
              (fn? crumb)    (expand-path-with state base crumb)
-             (regex? crumb) (expand-path-with state base #(re-find crumb (name %)))
+             (regex? crumb) (expand-path-with state base #(re-find crumb (name* %)))
              :default       [(conj base crumb)]))
           (expand-paths-once [base-paths crumb]
             (into #{} (mapcat #(expand-path-once % crumb) base-paths)))]

--- a/src/cljx/instar/core.cljx
+++ b/src/cljx/instar/core.cljx
@@ -4,7 +4,6 @@
 
 (def ^:private star? #{STAR})
 
-(defn- noop [x] x)
 
 (defn- name* [x]
   (if (number? x) (str x) (name x)))
@@ -68,11 +67,8 @@
     (transform-resolved-paths m x)))
 
 (defn get-in-paths [m & args]
-  (let [args-with-bogus-op (apply concat (for [arg args] [arg noop])) ; ..because resolve-paths-for-transform expects pairs
-        paths (resolve-paths-for-transform m args-with-bogus-op)]
-    (for [[p _] (partition 2 paths)]
-      [p (get-in m p)])))
+  (for [path (mapcat (partial expand-path m) args)]
+    [path (get-in m path)]))
 
 (defn get-values-in-paths [& args]
-  (for [[path value] (apply get-in-paths args)]
-    value))
+  (map second (apply get-in-paths args)))

--- a/test/instar/core-test.cljs
+++ b/test/instar/core-test.cljs
@@ -2,7 +2,7 @@
   (:require-macros [cemerick.cljs.test
                     :refer (is deftest with-test run-tests testing test-var)])
   (:require [cemerick.cljs.test :as t]
-            [instar.core :refer [transform expand-path]]))
+            [instar.core :refer [transform expand-path get-values-in-paths]]))
 
 (def test-state1 {:foo {:1 {:q1 1}, :2 {:q2 2}, :3 {:q3 3}}})
 (def test-state2 {:foo {:1 {:q1 {:a 1}}, :2 {:q2 2}, :3 {:q3 3}}})
@@ -57,3 +57,21 @@
   (testing "simplest transform"
     (is (= (transform {} [:test] 1)
            {:test 1}))))
+
+(deftest get-values
+  (testing "get-values-in-paths"
+    (is (= (get-values-in-paths {:a {:b [:c :d]
+                                     :e #{:f}}
+                                 :b {:b [:a :b]
+                                     :h #{:f :g}}}
+                                [:a * #"\w"]
+                                [* :b 1]
+                                [* * :f])
+           ;; not especially pleased by the nils, as :f cannot key vector
+           ;; consider:
+           ;; (transform {:a {:b [:c :d]
+           ;;                 :e #{:f}}
+           ;;             :b {:b [:a :b]
+           ;;                 :h #{:f :g}}}
+           ;;            [* * :f] 3)
+           [:c :d :d :b nil :f nil :f]))))


### PR DESCRIPTION
As a prelude to adding [capture](https://github.com/boxed/instar/issues/9) support, added more test coverage and fixed a minor bug (regex in path will explode on vector data).

Expose another (debatable) bug, involving leaf keys that are not compatible with parent data still being resolved, eg `[...path :a]` where `[...path]` has resolved to a vector.

Adding support for indexed collections has opened a can of worms it seems :)